### PR TITLE
Set minimum Java version to 11

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: [ 21 ]
+        java: [ 11, 17, 21 ]
     if: github.repository == 'opensearch-project/opensearch-system-templates'
     runs-on: ubuntu-latest
     container:
@@ -40,7 +40,7 @@ jobs:
     if: github.repository == 'opensearch-project/opensearch-system-templates'
     strategy:
       matrix:
-        java: [ 21 ]
+        java: [ 11, 17, 21 ]
         os: [windows-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -82,8 +82,8 @@ allprojects {
     }
 
     java {
-        targetCompatibility = JavaVersion.VERSION_21
-        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_11
     }
 }
 


### PR DESCRIPTION
### Description
Set minimum Java version to 11 on the 2.17 branch. This will need to be forward ported to the 2.x branch as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
