### PR TITLE
Bump custom-codecs version to 2.17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ opensearchplugin {
 }
 
 dependencies {
-    zipArchive group: 'org.opensearch.plugin', name:'opensearch-custom-codecs', version: "2.17.0.0-SNAPSHOT"
+    zipArchive group: 'org.opensearch.plugin', name:'opensearch-custom-codecs', version: "2.17.1.0-SNAPSHOT"
 }
 
 allprojects {


### PR DESCRIPTION
### Description
Bump version to 2.17.1 from 2.17.0 for custom-codecs dependency

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
