### PR TITLE
Use common variable for versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,13 @@ buildscript {
         opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
+        plugin_version = opensearch_version.tokenize('-')[0] + '.0'
+        if (buildVersionQualifier) {
+            plugin_version += "-${buildVersionQualifier}"
+        }
+        if (isSnapshot) {
+            plugin_version += "-SNAPSHOT"
+        }
     }
 
     repositories {
@@ -73,13 +80,7 @@ configurations {
 
 allprojects {
     group 'org.opensearch'
-    version = opensearch_version.tokenize('-')[0] + '.0'
-    if (buildVersionQualifier) {
-        version += "-${buildVersionQualifier}"
-    }
-    if (isSnapshot) {
-        version += "-SNAPSHOT"
-    }
+    version plugin_version
 
     java {
         targetCompatibility = JavaVersion.VERSION_21
@@ -96,7 +97,7 @@ opensearchplugin {
 }
 
 dependencies {
-    zipArchive group: 'org.opensearch.plugin', name:'opensearch-custom-codecs', version: "3.0.0.0-SNAPSHOT"
+    zipArchive group: 'org.opensearch.plugin', name:'opensearch-custom-codecs', version: plugin_version
 }
 
 allprojects {


### PR DESCRIPTION
### Description
Use common variable for versioning since plugins are tightly coupled and can use same version overall. To avoid scenarios like https://github.com/opensearch-project/opensearch-system-templates/pull/31

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
