### PR TITLE
Bumping opensearch-system-templates plugin version to 3.0.0-alpha1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,9 @@
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-alpha1-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
         plugin_version = opensearch_version.tokenize('-')[0] + '.0'
         if (buildVersionQualifier) {
             plugin_version += "-${buildVersionQualifier}"


### PR DESCRIPTION
### Description
Bumping opensearch-system-templates plugin version to 3.0.0-alpha1

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
