### PR TITLE
Add ci.opensearch.org/m2/ mirror for plugin resolution (opensearch-system-templates)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
@@ -71,6 +72,7 @@ apply plugin: 'opensearch.java-agent'
 
 repositories {
     mavenLocal()
+    maven { url = "https://ci.opensearch.org/m2/" }
     maven { url = "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url = "https://plugins.gradle.org/m2/" }

--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ buildscript {
 
     repositories {
         mavenLocal()
-        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
+        maven { url = "https://ci.opensearch.org/m2/" }
         mavenCentral()
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url = "https://plugins.gradle.org/m2/" }
@@ -72,8 +72,8 @@ apply plugin: 'opensearch.java-agent'
 
 repositories {
     mavenLocal()
-    maven { url = "https://ci.opensearch.org/m2/" }
     maven { url = "https://ci.opensearch.org/maven2/" }
+    maven { url = "https://ci.opensearch.org/m2/" }
     mavenCentral()
     maven { url = "https://plugins.gradle.org/m2/" }
     maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,8 +8,8 @@
 
 pluginManagement {
     repositories {
-        maven { url "https://ci.opensearch.org/m2/" }
         maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/m2/" }
         gradlePluginPortal()
         mavenCentral()
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@
 
 pluginManagement {
     repositories {
+        maven { url "https://ci.opensearch.org/m2/" }
         maven { url "https://ci.opensearch.org/maven2/" }
         gradlePluginPortal()
         mavenCentral()


### PR DESCRIPTION
### Description
Add ci.opensearch.org/m2/ mirror for plugin resolution (opensearch-system-templates)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5135909975

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).