### PR TITLE
Use Eclipse P2 mirror (opensearch-system-templates)

### DIFF
--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -30,7 +30,7 @@ spotless {
         '\\#java|\\#org.opensearch|\\#org.hamcrest|\\#'
     )
 
-    eclipse().configFile rootProject.file('gradle/formatterConfig.xml')
+    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('gradle/formatterConfig.xml')
     trimTrailingWhitespace()
     endWithNewline()
 


### PR DESCRIPTION
Routes Spotless Eclipse P2 downloads through https://ci.opensearch.org/ to avoid direct download.eclipse.org outages.

Tracking bulletin: https://github.com/opensearch-project/opensearch-build/issues/6421#issuecomment-5271186726